### PR TITLE
for python 2.7, import from urlparse

### DIFF
--- a/yahooscraper/login.py
+++ b/yahooscraper/login.py
@@ -4,7 +4,11 @@ Login page
 
 import requests
 from bs4 import BeautifulSoup
-from urllib.parse import urljoin
+#adds support for python 2.7
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 
 URL = 'https://login.yahoo.com'


### PR DESCRIPTION
Hey, love what you have done here!  I'm running 2.7, and only had to make one small tweak to get yahooscraper running on my machine.  Thought I would contribute it back - if this is helpful, all yours; if not, feel free to decline this pull request, no worries.

Reading from the python3 porting [guide](http://python3porting.com/noconv.html), the try/except logic seems to be the canonical way to do the `if python 3, do x; else do y` dance - that's what I've done here.
